### PR TITLE
refactor: replace sleep with explicit wait

### DIFF
--- a/selenium_scraper.py
+++ b/selenium_scraper.py
@@ -4,7 +4,6 @@ from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 from bs4 import BeautifulSoup
-import time
 import pandas as pd
 from google_play_scraper import app
 from datetime import datetime
@@ -64,7 +63,9 @@ class Main_driver:
                 button.click()
                 print("Кнопка нажата!")
 
-                time.sleep(5)
+                WebDriverWait(self.driver, 10).until(
+                    lambda d: d.page_source != page_source_before
+                )
 
                 page_source_after = self.driver.page_source
                 soup_after = BeautifulSoup(page_source_after, "html.parser")


### PR DESCRIPTION
## Summary
- use WebDriverWait instead of a fixed five-second delay when toggling to tablet view
- drop unused time import

## Testing
- `python -m py_compile selenium_scraper.py`


------
https://chatgpt.com/codex/tasks/task_e_688e57b8a7a8832abb8b0963dc097a50